### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -3,9 +3,8 @@ lab:
   title: Exercise Title
   module: Learn module title
   description: Before you can start this exercise, you will need to...
-  duration: 72 minutes
+  duration: 30 minutes
   level: 100
-  islab: true
 ---
 
 <!--

--- a/Instructions/Labs/01-exercise-template.md
+++ b/Instructions/Labs/01-exercise-template.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise Title'
-    module: 'Learn module title'
+  title: Exercise Title
+  module: Learn module title
+  description: Before you can start this exercise, you will need to...
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
+
 <!--
 Edit the metadata above to manage the list of exercises in the home page of the GitHub site that gets generated.
 You can delete the module and edit index.md in the root of the repo to customize the display so that only the exercises are listed

--- a/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
+++ b/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Exercise - Create classes and objects in C#'
-    module: 'Get started with classes and objects in C#'
+  title: Exercise - Create classes and objects in C#
+  module: Get started with classes and objects in C#
+  description: In this exercise, you create a console app that uses class definitions to instantiate objects.
+  duration: 25 minutes
+  level: 100
+  islab: true
 ---
-
 
 # Create classes and objects in C#
 

--- a/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
+++ b/Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md
@@ -4,8 +4,7 @@ lab:
   module: Get started with classes and objects in C#
   description: In this exercise, you create a console app that uses class definitions to instantiate objects.
   duration: 25 minutes
-  level: 100
-  islab: true
+  level: 200
 ---
 
 # Create classes and objects in C#

--- a/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
+++ b/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
@@ -5,7 +5,6 @@ lab:
   description: In this exercise, you encapsulate the data and behavior of a class by implementing properties and methods.
   duration: 30 minutes
   level: 200
-  islab: true
 ---
 
 # Update a class with properties and methods in CSharp

--- a/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
+++ b/Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Exercise - Update a class with properties and methods in C#'
-    module: 'Implement properties and methods in C# classes'
+  title: Exercise - Update a class with properties and methods in C#
+  module: Implement properties and methods in C# classes
+  description: In this exercise, you encapsulate the data and behavior of a class by implementing properties and methods.
+  duration: 30 minutes
+  level: 200
+  islab: true
 ---
-
 
 # Update a class with properties and methods in CSharp
 

--- a/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
+++ b/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
@@ -1,9 +1,12 @@
 ---
 lab:
-    title: 'Exercise - Implement classes in C# applications'
-    module: 'Implement classes in C# applications'
+  title: Exercise - Implement classes in C# applications
+  module: Implement classes in C# applications
+  description: In this exercise, you encapsulate the data and behavior of a class by implementing properties and methods.
+  duration: 30 minutes
+  level: 200
+  islab: true
 ---
-
 
 # Implement classes in C# applications
 

--- a/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
+++ b/Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md
@@ -5,7 +5,6 @@ lab:
   description: In this exercise, you encapsulate the data and behavior of a class by implementing properties and methods.
   duration: 30 minutes
   level: 200
-  islab: true
 ---
 
 # Implement classes in C# applications


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/01-exercise-template.md` (description,duration,level,islab)
- `Instructions/Labs/l2p2-lp1-m1-exercise-create-classes-and-objects-in-csharp.md` (description,duration,level,islab)
- `Instructions/Labs/l2p2-lp1-m2-exercise-update-class-properties-methods.md` (description,duration,level,islab)
- `Instructions/Labs/l2p2-lp1-m3-exercise-implement-classes-csharp-apps.md` (description,duration,level,islab)
